### PR TITLE
Add support for custom compilerOptions for vue sfc.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,8 @@ const vuePlugin = (opts: Options = {}) => <esbuild.Plugin>{
                 compilerOptions: {
                     inSSR: opts.renderSSR,
                     directiveTransforms: transforms,
-                    bindingMetadata: script?.bindings
+                    bindingMetadata: script?.bindings,
+                    ...opts.compilerOptions
                 }
             });
 
@@ -239,7 +240,7 @@ const vuePlugin = (opts: Options = {}) => <esbuild.Plugin>{
             return {
                 contents: result.code,
                 warnings: result.tips.map(o => ({ text: o })),
-                loader: "js",
+                loader: "ts",
                 resolveDir: path.dirname(args.path),
             }
         }));

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { DirectiveNode, ElementNode, TransformContext } from "@vue/compiler-core";
+import { CompilerOptions, DirectiveNode, ElementNode, TransformContext } from "@vue/compiler-core";
 import { IndexOptions } from "./html";
 
 export type Options = {
@@ -64,4 +64,9 @@ export type Options = {
         options?: any;
         plugins?: any[];
     }
+
+    /**
+     * Option to add custom compiler options for vue sfc
+     */
+    compilerOptions?: CompilerOptions
 }


### PR DESCRIPTION
Add compilerOptions to options object. This resolves 2 main issues:
- It is now possible to use the isCustomElement function to tell the vue compiler in dev that an element is a custom element.
- You can set "expressionPlugins: ['typescript']". This allows you to add typescript typing in the template. Code like <div :id="value!"> should now be possible to write. 