### PR TITLE
add support for script src imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,8 @@ const vuePlugin = (opts: Options = {}) => <esbuild.Plugin>{
             let code = "";
 
             if (descriptor.script || descriptor.scriptSetup) {
-                code += `import script from "${encPath}?type=script";`
+                const src = (descriptor.script && !descriptor.scriptSetup && descriptor.script.src) || encPath
+                code += `import script from "${src}?type=script";`
             } else {
                 code += "const script = {};"
             }


### PR DESCRIPTION
Add check for `descriptor.script.src` to allow [script src-imports](https://vuejs.org/api/sfc-spec.html#src-imports).

Supports a template that has a script in a separate file, eg:

```vue
<script src="./button.js"></script>
<template>
  <span class="my-button">
    <slot></slot>
  </span>
</template
```

Fixes #7