### PR TITLE
Fix generate html  insert script assets once

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -63,7 +63,7 @@ export async function generateIndexHTML(result: BuildResult, opts: IndexOptions,
             link.attr("rel", item.prefetch ? "prefetch" : "preload");
             link.attr("href", item.href);
             link.attr("as", item.as);
-            link.insertAfter($("head :last-child"))
+            $("head").append(link)
         }
     }
 
@@ -83,11 +83,12 @@ export async function generateIndexHTML(result: BuildResult, opts: IndexOptions,
         if (ext === ".js") {
             const script = $("<script>");
             script.attr("src", name);
-            script.insertAfter($("body :last-child"));
+            $("body").append(script)
         } else if (ext === ".css") {
             const link = $("<link rel='stylesheet'>")
             link.attr("href", name);
-            link.insertAfter($("head :last-child"))
+            $("head").append(link)
+
         }
     }
 


### PR DESCRIPTION
Fixes #14  html generation inserting too many script assets.

Uses `$("body").append(script)` as a more selective selector.

For consistency the `head` style and prefetch/preload inserts use `$("head").append(link)` (though in normal situations the head does not have nested elements so was not inserting too many elements).

