### PR TITLE
Fix for styling import in workspaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,8 @@ const vuePlugin = (opts: Options = {}) => <esbuild.Plugin>{
                     ],
                     importer: [
                         (url: string) => {
-                            const modulePath = path.join(process.cwd(), "node_modules", url);
+                            const projectRoot = process.env.npm_config_local_prefix || process.cwd()
+                            const modulePath = path.join(projectRoot, "node_modules", url);
 
                             if (fs.existsSync(modulePath)) {
                                 return { file: modulePath }


### PR DESCRIPTION
There is currently an issue where the resolved path is not correct if the project is part of a workspace. 
If the main project has a path: ".../my-project/"
sub-project has a path: ".../my-project/packages/sub-project/"

then the node_modules will be located at ".../my-project/node_modules" the resolved modulePath will be ".../my-project/packages/sub-project/node_modules". The latter path does not exist when working inside a project with workspaces. 
The env variable "process.env.npm_config_local_prefix" provides a path to the project root dir.