### PR TITLE
Rewrote preprocessor importer to comply with new Dart Sass

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as esbuild from "esbuild";
 import * as path from "path";
 import * as fs from 'fs';
 import * as crypto from "crypto";
+import { pathToFileURL } from 'url';
 
 import ts from "typescript";
 
@@ -271,19 +272,19 @@ const vuePlugin = (opts: Options = {}) => <esbuild.Plugin>{
                     includePaths: [
                         path.dirname(args.path)
                     ],
-                    importer: [
-                        (url: string) => {
+                    importer: {
+                        findFileUrl(url: string) {
                             const projectRoot = process.env.npm_config_local_prefix || process.cwd()
-                            const modulePath = path.join(projectRoot, "node_modules", url);
+                            const modulePath = path.join(projectRoot, "node_modules", url)
 
-                            if (fs.existsSync(modulePath)) {
-                                return { file: modulePath }
-                            }
+                            if (fs.existsSync(modulePath)) return pathToFileURL(modulePath)
+
+                            const replacedPath = replaceRules(url);
+                            if (fs.existsSync(replacedPath)) return pathToFileURL(replacedPath)
 
                             return null
                         },
-                        (url: string) => ({ file: replaceRules(url) })
-                    ]
+                    },
                 }, opts.preprocessorOptions),
                 scoped: style.scoped,
             });


### PR DESCRIPTION
To make the importer in your Sass preprocessOptions compatible with the new compileString() API (introduced in Dart Sass v1.56.0), you need to adjust the format of the importer to follow the new Importer API, which has changed how custom importers work.

⚠️ Key Changes in Dart Sass 1.56.0+ (and sass.compileString)
- The new importer API uses an Importer object, not just a function.
- This object must define a findFileUrl(url) method that returns a URL | null | Promise<URL | null>

In this PR I have rewritten the preprocessor importer to comply with the new compileString API. Tested locally and it now works with newer Vue-versions which was the original issue reported here: https://github.com/pipe01/esbuild-plugin-vue3/issues/30. (Current version of this package does not work with newer versions of vue or @vue/compiler-sfc > 3.5.11)